### PR TITLE
Update number sources and articles press review edit page

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -35,8 +35,6 @@ class ArticlesController < ApplicationController
   end
 
   def destroy
-    @article = Article.find(params[:id])
-    @article.topic_articles.destroy_all
   end
 
   private

--- a/app/controllers/topic_articles_controller.rb
+++ b/app/controllers/topic_articles_controller.rb
@@ -24,6 +24,14 @@ class TopicArticlesController < ApplicationController
 
   end
 
+  def destroy
+    @topic_article = TopicArticle.find(params[:topic_article_id])
+    @topic = @topic_article.topic
+    @topic_article.destroy
+    @topic.update_sources_json
+    @topic.update_number_of_sources
+  end
+
   private
   def article_params
     params.require(:article).permit(:source_id, :title, :pic_url, :date, :abstract, :words_count, :aylien_id, :source_url, :opposite_url)

--- a/app/controllers/topic_articles_controller.rb
+++ b/app/controllers/topic_articles_controller.rb
@@ -22,6 +22,9 @@ class TopicArticlesController < ApplicationController
     @topic_article.topic = @topic
     @topic_article.save
 
+    @topic.update_sources_json
+    @topic.update_number_of_sources
+
   end
 
   def destroy

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -10,6 +10,9 @@ class Topic < ApplicationRecord
   RELEVANCE_INDEX = 15
   OBSOLETE_TIME = 24 * 60 * 60
 
+  # FIXME : really need to do that ?
+  # before_update :update_sources_json
+
 
   def self.get
     topics = []
@@ -223,6 +226,25 @@ class Topic < ApplicationRecord
       return false unless title_words.include? word
     end
     true
+  end
+
+  def update_number_of_sources
+    sources = []
+    self.articles.each do |article|
+      sources << article.source.name unless sources.include?(article.source.name)
+    end
+    self.number_sources = sources.count
+    self.save
+  end
+
+  def update_sources_json
+    sources_json = {sources: []}
+    self.articles.each do |article|
+      sources_json[:sources] << article.source.name unless sources_json[:sources].include?(article.source.name)
+    end
+    # to check
+    self.sources_json = sources_json
+    self.save
   end
 
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -142,7 +142,7 @@ class Topic < ApplicationRecord
 
       hash_source_url = {}
       stories.each do |story|
-        next if title_include_words?(story.title, topic_main_words)
+        next unless title_include_words?(story.title, topic_main_words)
         next if (story.media[0].url.empty? || story.summary.sentences.join("\n") == "")
         hash_source_url[Source.where(aylien_id: story.source.id.to_i).first.name] = story.links.permalink
       end

--- a/app/views/article_bookmarks/index.html.erb
+++ b/app/views/article_bookmarks/index.html.erb
@@ -71,7 +71,6 @@
         nbarticle = nbarticle - 1;
 
         $('.articles_bookmarked').data('number', nbarticle);
-        console.log(nbarticle);
         $(this).closest('.card').fadeOut('slow', function(){
           $(this).remove();
         });

--- a/app/views/article_bookmarks/index.html.erb
+++ b/app/views/article_bookmarks/index.html.erb
@@ -18,9 +18,9 @@
     <div class="flex-box-space-around font-header-app">
       <div class = "wrapper-white">
         <div>
-          <h2 id="number_articles_bookmarked" class="font-header-app"><%= pluralize(@article_bookmarks.count, 'article sauvegardé', plural: 'articles sauvegardés')%></h2>
-          <%= content_tag :div, class: "articles_bookmarked", data: {number: @article_bookmarks.count} do %>
-          <% end %>
+          <h2 id="number_articles_bookmarked" class="font-header-app" data-number="<%= @article_bookmarks.count %>">
+            <%= pluralize(@article_bookmarks.count, 'article sauvegardé', plural: 'articles sauvegardés')%>
+          </h2>
         </div>
       </div>
     </div>
@@ -67,10 +67,10 @@
       });
 
       $('.unbookmark').click( function() {
-        var nbarticle = $('.articles_bookmarked').data('number')
+        var nbarticle = $('#number_articles_bookmarked').data('number')
         nbarticle = nbarticle - 1;
 
-        $('.articles_bookmarked').data('number', nbarticle);
+        $('#number_articles_bookmarked').data('number', nbarticle);
         $(this).closest('.card').fadeOut('slow', function(){
           $(this).remove();
         });

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -2,7 +2,9 @@
   <div class = "wrapper-white">
     <div>
       <h2 class="font-header-app">Revue de presse pour "<%= @topic.name %>"</h2>
-      <h4 class="font-header-app"><%= @topic.articles.count %> Articles - <%= @topic.number_sources %> sources</h4>
+      <h4 class="font-header-app"><span id="number_articles_in_pr" class="font-header-app"><%= pluralize(@topic.articles.count, 'article', plural: 'articles')%></span>
+          <%= content_tag :div, class: "articles_in_pr", data: {number: @topic.articles.count} do %>
+          <% end %> - <%= @topic.number_sources %> sources</h4>
     </div>
   </div>
 
@@ -63,9 +65,14 @@
     $(document).ready(function(){
 
       $('.suppress').click( function() {
+        var nbarticle = $('.articles_in_pr').data('number')
+        nbarticle = nbarticle - 1;
+
+        $('.articles_in_pr').data('number', nbarticle);
         $(this).closest('.list-group-item').fadeOut('slow', function(){
           $(this).remove();
         });
+        $('#number_articles_in_pr').html(nbarticle + " article(s)");
       });
 
       $('.up').click( function() {

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -3,11 +3,12 @@
     <div>
       <h2 class="font-header-app">Revue de presse pour "<%= @topic.name %>"</h2>
       <h4 class="font-header-app">
-        <span id="number_articles_in_pr" class="font-header-app">
+        <span id="number_articles_in_pr" class="font-header-app" data-number="<%= @topic.articles.count %>">
           <%= pluralize(@topic.articles.count, 'article', plural: 'articles')%>
         </span>
-        <span class="articles_in_pr"  data-number="<%= @topic.articles.count %>">
-          - <%= @topic.number_sources %> sources
+        -
+        <span id="number_sources_in_pr" class="font-header-app" data-number="<%= @topic.number_sources %>">
+          <%= pluralize(@topic.number_sources, 'source', plural: 'sources')%>
         </span>
       </h4>
     </div>
@@ -70,10 +71,9 @@
     $(document).ready(function(){
 
       $('.suppress').click( function() {
-        var nbarticle = $('.articles_in_pr').data('number')
+        var nbarticle = $('#number_articles_in_pr').data('number');
         nbarticle = nbarticle - 1;
-
-        $('.articles_in_pr').data('number', nbarticle);
+        $('#number_articles_in_pr').data('number', nbarticle);
         $(this).closest('.list-group-item').fadeOut('slow', function(){
           $(this).remove();
         });

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -2,9 +2,14 @@
   <div class = "wrapper-white">
     <div>
       <h2 class="font-header-app">Revue de presse pour "<%= @topic.name %>"</h2>
-      <h4 class="font-header-app"><span id="number_articles_in_pr" class="font-header-app"><%= pluralize(@topic.articles.count, 'article', plural: 'articles')%></span>
-          <%= content_tag :div, class: "articles_in_pr", data: {number: @topic.articles.count} do %>
-          <% end %> - <%= @topic.number_sources %> sources</h4>
+      <h4 class="font-header-app">
+        <span id="number_articles_in_pr" class="font-header-app">
+          <%= pluralize(@topic.articles.count, 'article', plural: 'articles')%>
+        </span>
+        <span class="articles_in_pr"  data-number="<%= @topic.articles.count %>">
+          - <%= @topic.number_sources %> sources
+        </span>
+      </h4>
     </div>
   </div>
 

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -41,7 +41,9 @@
           <div class="flex-box-space-between table-buttons">
 <!--             <%= link_to 'Haut', class: 'btn btn-bordered btn-bordered-info up' %>
             <%= link_to 'Bas', class: 'btn btn-bordered btn-bordered-info down' %> -->
-            <%= form_tag article_path(article), method: :delete do %>
+            <% topic_article = TopicArticle.where(article: article).where(topic: @topic).first %>
+            <%= form_tag topic_article_path(topic_article), method: :delete do %>
+              <%= hidden_field_tag 'topic_article_id', topic_article.id %>
               <%= submit_tag 'Supprimer', class: 'btn btn-bordered btn-bordered-info suppress' %>
             <% end %>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   end
 
   post 'topic_article', to: 'topic_articles#create'
+  delete 'topic_article', to: 'topic_articles#destroy'
 
   post 'bookmark', to: 'article_bookmarks#create'
   delete 'bookmark', to: 'article_bookmarks#destroy'


### PR DESCRIPTION
The number of articles in a press review is now automatically updated in JS when one deletes an article from the press review. But the number of sources is not automatically updated yet in JS.

I created two methods to update the number of sources and the sources json of a topic when one deletes or add an article to a press review.
@guillaumecabanel can you review that code first please ?
Once it's ok for you, I will code the automatic update of number of sources in JS when one deletes an article from the press review.
Thanks !